### PR TITLE
Add skipLaunch option to emulator.install

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const
 	async        = require('async'),
 	EventEmitter = require('events').EventEmitter,
 	magik        = require('./lib/utilities').magik,
+	__ = appc.i18n(__dirname).__,
 
 	packageJson  = require('./package.json'),
 

--- a/lib/emulator.js
+++ b/lib/emulator.js
@@ -152,12 +152,14 @@ function isRunning(udid, options, callback) {
  *
  * @param {String} udid - The UDID of the Windows Phone emulator to launch or null if you want windowslib to pick one.
  * @param {Object} [options] - An object containing various settings.
+ * @param {String} [options.appPath] - The path to the Windows Phone app to install after launching the Windows Phone Emulator.
  * @param {String} [options.assemblyPath=%WINDIR%\Microsoft.NET\assembly\GAC_MSIL] - Path to .NET global assembly cache.
  * ?????????????????????????????????????????????????????????????????? @param {Boolean} [options.autoExit=false] - When "appPath" has been specified, causes the iOS Simulator to exit when the autoExitToken has been emitted to the log output.
  * ?????????????????????????????????????????????????????????????????? @param {String} [options.autoExitToken=AUTO_EXIT] - A string to watch for to know when to quit the emulator when "appPath" has been specified.
  * @param {Boolean} [options.bypassCache=false] - When true, re-detects all emulators.
  * @param {Boolean} [options.killIfRunning=false] - Kill the Windows Phone emulator if already running.
  * @param {Object} [options.requiredAssemblies] - An object containing assemblies to check for in addition to the required windowslib dependencies.
+ * @param {Boolean} [options.skipLaunch] - Whether we should just install without launching.
  * @param {Boolean} [options.tasklist] - The path to the 'tasklist' executable.
  * @param {Number} [options.timeout] - Number of milliseconds to wait for the emulator to launch and launch the app before timing out. Must be at least 1 millisecond.
  * @param {String} options.wpsdk - A specific Windows Phone version to query.
@@ -261,7 +263,7 @@ function launch(udid, options, callback) {
 
 						var cmd = results.windowsphone[emuHandle.wpsdk].deployCmd,
 							args = [
-								'/installlaunch',
+								options.skipLaunch ? '/install' : '/installlaunch',
 								options.appPath,
 								'/targetdevice:' + emuHandle.index
 							],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",


### PR DESCRIPTION
So we can install apps/libs without trying to launch them. In doing dev work on windows build/wp-run command, we need to install a dependency appx on the emulator without trying to launch that dependency before we install and launch the _real_ appx.
