### PR TITLE
v0.1.5 - Make wstool launch more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+0.1.5 (12/05/2014)
+-------------------
+ * Made wstool launch of WinStore apps more robust
+
+0.1.4 (12/03/2014)
+-------------------
+ * Detects Visual Studio Express editions and have a better error reporting when Visual Studio is not found
+ * Added missing node-appc reference in the index.js
+
+0.1.3 (12/01/2014)
+-------------------
+ * add option to skipLaunch when installing Windows Phone app
+
 0.1.2 (11/25/2014)
 -------------------
  * Added detection of the XapSignTool executable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windowslib",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Windows Phone Utility Library",
 	"keywords": [
 		"appcelerator",

--- a/wstool/wstool.cs
+++ b/wstool/wstool.cs
@@ -44,7 +44,13 @@ namespace wstool
 				foreach (var appKeyName in appListKey.GetSubKeyNames()) {
 					if (appKeyName.IndexOf(appid + "_" + version + "_") == 0) {
 						var appKey = appListKey.OpenSubKey(appKeyName);
-						var subKey = appKey.OpenSubKey("Server\\App.wwa");
+						var appClassKey = appKey.OpenSubKey("ActivatableClassId\\App");
+						if (appClassKey == null)
+						{
+							appClassKey = appKey.OpenSubKey("ActivatableClassId\\App.wwa");
+						}
+						String serverId = (String)appClassKey.GetValue("Server");
+						var subKey = appKey.OpenSubKey("Server\\" + serverId);
 						appUserModelId = (String)subKey.GetValue("AppUserModelId");
 						break;
 					}
@@ -57,10 +63,16 @@ namespace wstool
 					if (p == 0) {
 						int q = appKeyName.IndexOf("_", p + 1);
 						if (q != -1) {
-							string thisVersion = appKeyName.Substring(p + appid.Length + 1, q);
+							string thisVersion = appKeyName.Substring(p + 1, q);
 							if (lastVersion == null || String.Compare(thisVersion, lastVersion, true) > 0) {
 								var appKey = appListKey.OpenSubKey(appKeyName);
-								var subKey = appKey.OpenSubKey("Server\\App.wwa");
+								var appClassKey = appKey.OpenSubKey("ActivatableClassId\\App");
+								if (appClassKey == null)
+								{
+									appClassKey = appKey.OpenSubKey("ActivatableClassId\\App.wwa");
+								}
+								String serverId = (String)appClassKey.GetValue("Server");
+								var subKey = appKey.OpenSubKey("Server\\" + serverId);
 								if (subKey != null) {
 									appUserModelId = (String)subKey.GetValue("AppUserModelId");
 									lastVersion = thisVersion;


### PR DESCRIPTION
This makes the wstoool.cs more robust so it doesn't break if no version is specified, and it looks in more locations to determine the Server subkey to examine for AppUserModelId.
